### PR TITLE
Allow self-signed certificates to be pinned

### DIFF
--- a/src/tak.erl
+++ b/src/tak.erl
@@ -125,6 +125,8 @@ verify_pin(PinCert, valid_peer, PinCert) ->
     {valid, PinCert};
 verify_pin(_Cert, {extension, _}, PinCert) ->
     {unknown, PinCert};
+verify_pin(PinCert, {bad_cert, selfsigned_peer}, PinCert) ->
+    {valid, PinCert};
 verify_pin(_Cert, {bad_cert, _} = Reason, _PinCert) ->
     {fail, Reason};
 verify_pin(_Cert, valid, PinCert) ->


### PR DESCRIPTION
Prior to this changeset, a self-signed certificate would always fail to
be recognized even if valid. This patch allows self-signed certificate
pinning to take place and be recognized as valid.
