### PR TITLE
change pem_data type to iodata

### DIFF
--- a/src/tak.erl
+++ b/src/tak.erl
@@ -27,7 +27,7 @@
 
 %% Types
 
--type pem_data() :: iolist().
+-type pem_data() :: iodata().
 -type cert() :: #'OTPCertificate'{}.
 -type cert_chain() :: [cert()].
 -type pin() :: {CACert::cert(),


### PR DESCRIPTION
Using tak from Elixir gave a dialyzer error when passing a binary string to `tak:pem_to_ssl_options/1`
This patch allows the pem data to be binary or iolist.